### PR TITLE
added helper for angular tree

### DIFF
--- a/angular/src/app/playlists/angular_tree_helper.js
+++ b/angular/src/app/playlists/angular_tree_helper.js
@@ -1,0 +1,65 @@
+angularTree = function(playlists) {
+	var tree = {}
+	var subtree = {}
+
+	for(i in playlists) {
+		subtree = tree
+		parts = playlists[i].split('/')
+		for(j in parts) {
+			if(!(parts[j] in subtree)) {
+				subtree[parts[j]] = {}
+			}
+			subtree = subtree[parts[j]]
+		}
+	}
+
+	//create the ugly "item" thing required by the plugin
+	items = []
+	subitems = items
+
+	hastitle = function(title, subitems) {
+		for(i in subitems) {if(subitems[i].title === title){return true}}
+		return false
+	}
+
+	getitems = function(title, subitems) {
+		for(i in subitems) {if(subitems[i].title === title){return subitems[i].items}}
+		return 'something went wrong' 
+	}
+
+	addItem = function(path, item) {
+		subitems = items
+		for(var i = 0, l = path.length; i < l; i++) {
+			if(hastitle(path[i], subitems)) {
+				subitems = getitems(path[i], subitems) 
+			} else {
+				newitems = []
+				subitems.push({
+					'title': path[i],
+					'items' : newitems
+				})
+				subitems = newitems
+			}
+		}
+	}
+
+	addAllItems = function myself(path, node) {
+		for(item in node) {
+			path.push(item)
+			addItem(path, item)
+			myself(path, node[item]) 
+			path.pop(item)
+		}
+	}
+
+	addIds = function myself(reclevel, parentid, items) {
+		for(var i = 0, l = items.length; i < l; i++) {
+			items[i].id = parentid + Math.pow(10, reclevel)*(i + 1)
+			myself(reclevel+1, items[i].id, items[i].items)
+		}
+	}
+
+	addAllItems([],tree)
+	addIds(0, 0, items)
+	return items
+}


### PR DESCRIPTION
I use this with spotify and noticed the "flat" way that the playlists are displayed with the restful paths embedded. I created a helper for the [angular-ui-tree](https://github.com/JimLiu/angular-ui-tree) project hoping to get it pulled in. 

This helper creates data from a list of playlists as was in the [demo](http://jimliu.github.io/angular-ui-tree/) 

There is no need to add jquery and, since everything will happen on the client side, it won't bog down raspberry pi users (like myself).

**edit** I did not have a way of testing this and I am not very familiar with the angular framework but I was hoping to get the spotify "folder" type view. Sorry it's not completely integrated.

**edit2** After thinking about it a bit more, I'm guessing it wouldn't be too difficult to add this kind of tree view as an option under the settings tab.
