### PR TITLE
Adding the music provider in track list

### DIFF
--- a/src/app/widgets/track.js
+++ b/src/app/widgets/track.js
@@ -27,6 +27,10 @@ angular.module('moped.widgets')
         scope.$emit('moped:playtrackrequest', scope.track);
         return false;
       };
+      scope.trackProvider = function() {
+        var provider = scope.track.uri.split(':')[0];
+        return (provider.charAt(0).toUpperCase() + provider.slice(1));
+      };
 
       var cleanUpTrackPlaybackStarted = scope.$on('mopidy:event:trackPlaybackStarted', function(event, data) {
         scope.isPlaying = data.tl_track.track.uri === scope.track.uri;

--- a/src/app/widgets/track.tpl.html
+++ b/src/app/widgets/track.tpl.html
@@ -4,7 +4,7 @@
   <div class="clearfix visible-xs" data-part="xs-sep1"></div>
   <div class="col-xs-1 visible-xs" data-part="xs-sp1"></div>
   <h4 class="col-xs-9 col-sm-5 list-group-item-heading">{{artistsAsString()}}</h4>
-  <div class="col-xs-1" data-part="trackduration">{{trackDuration()}}</div>
+  <div class="col-xs-1" data-part="trackduration">{{trackDuration()}} {{trackProvider()}}</div>
   <div class="clearfix hidden-xs" data-part="xs-sep2"></div>
   <div class="col-md-1 hidden-xs" data-part="xs-sp1"></div>
   <div class="col-md-5 hidden-xs" data-part="albumname">{{track.album.name}}</div>


### PR DESCRIPTION
I installed moped with friends at home.
The main problem we had is that when we have Youtube + Soundcloud + Spotify, it's sometimes hard to know where does a music comes from.

So I added the music provider service just beneath/next_to the duration of the song.
Everyone here seems to prefer this way.

The ideal would be to have tabs/filters to have songs from only one provider at a time. But maybe later :)

Julien
