### PR TITLE
Fix search queries containing spaces.

### DIFF
--- a/src/app/browse/browse.js
+++ b/src/app/browse/browse.js
@@ -56,11 +56,11 @@ angular.module('moped.browse', [
   });
 })
 
-.controller('ArtistCtrl', function ArtistController($scope, $timeout, $routeParams, mopidyservice, lastfmservice) {
+.controller('ArtistCtrl', function ArtistController($scope, $timeout, $routeParams, util, mopidyservice, lastfmservice) {
   var defaultAlbumImageUrl = 'assets/images/noalbum.png';
 
   var uri = $routeParams.uri;
-  var name = $routeParams.name;
+  var name = util.urlDecode($routeParams.name);
 
   $scope.artistSummary = '';
   $scope.albums = [];

--- a/src/app/search/search.js
+++ b/src/app/search/search.js
@@ -33,7 +33,7 @@ angular.module('moped.search', [
   $scope.albums = [];
   $scope.tracks = [];
 
-  $scope.query = $routeParams.query;
+  $scope.query = util.urlDecode($routeParams.query);
   if ($scope.query.length > 3) {
     mopidyservice.search($scope.query).then(function(results) {
       _.forEach(results, function(result) {


### PR DESCRIPTION
This should fix a problem introduced in e382665ced489c216b3f05cce538e17a0c59f2e8: Searches containing spaces do not work anymore, searching for "Some Band" lead to searches for "Some%Band". The search term gets encoded in SearchCtrl, but not decoded again in SearchResultsCtrl.

Also the artist name coming from the route does not get decoded correctly in ArtistCtrl.
