### PR TITLE
Fix browsing of playlists.

### DIFF
--- a/src/app/library/container.tpl.html
+++ b/src/app/library/container.tpl.html
@@ -1,0 +1,15 @@
+<div class="row view-title">
+  <h3>{{container.name}}</h3>
+</div>
+
+<div ng-if="directories.length != 0" class="list-group">
+  <directory directory="directory" ng-repeat="directory in directories" />
+</div>
+
+<div ng-if="playlists.length != 0" class="list-group">
+  <playlist playlist="playlist" ng-repeat="playlist in playlists" />
+</div>
+
+<div ng-if="tracks.length != 0" class="list-group">
+  <moped-track track-no="$index+1" track="track" ng-repeat="track in tracks track by $index" />
+</div>

--- a/src/app/library/directory.tpl.html
+++ b/src/app/library/directory.tpl.html
@@ -1,15 +1,4 @@
-<div class="row view-title">
-  <h3>{{directory.name}}</h3>
-</div>
-
-<div ng-if="directories.length != 0" class="list-group">
-  <sub-directory directory="directory" ng-repeat="directory in directories" />
-</div>
-
-<div ng-if="playlists.length != 0" class="list-group">
-  <moped-playlist playlist="playlist" ng-repeat="playlist in playlists" />
-</div>
-
-<div ng-if="tracks.length != 0" class="list-group">
-  <moped-track track-no="$index+1" track="track" ng-repeat="track in tracks track by $index" />
-</div>
+<a ng-href="#/library/{{directory.uri|directoryUrlEncode}}/{{directory.fullName|doubleUrlEncode}}" class="list-group-item row">
+    <div class="col-xs-1"><span class="glyphicon glyphicon-folder-close"></span></div>
+    <h4 class="col-xs-10 col-sm-5 list-group-item-heading">{{directory.name}}</h4>
+</a>

--- a/src/app/library/library.js
+++ b/src/app/library/library.js
@@ -7,8 +7,8 @@ angular.module('moped.library', [
 .config(function config($routeProvider) {
   $routeProvider
     .when('/library/:uri/:name?', {
-      templateUrl: 'library/directory.tpl.html',
-      controller: 'DirectoryCtrl',
+      templateUrl: 'library/container.tpl.html',
+      controller: 'ContainerCtrl',
       title: 'Directories'
     });
 })
@@ -29,22 +29,23 @@ angular.module('moped.library', [
   });
 })
 
-.controller('DirectoryCtrl', function DirectoryController($scope, $routeParams, mopidyservice, util) {
-  $scope.directory = { name: util.urlDecode($routeParams.name), uri: util.urlDecode($routeParams.uri) };
+.controller('ContainerCtrl', function ContainerController($scope, $routeParams, mopidyservice, util) {
+  $scope.container = { name: util.urlDecode($routeParams.name), uri: util.urlDecode($routeParams.uri) };
   $scope.directories = [];
   $scope.playlists = [];
   $scope.tracks = [];
 
-  mopidyservice.getDirectoryItems($scope.directory.uri).then(function(data) {
+  mopidyservice.getLibraryItems($scope.container.uri).then(function(data) {
     var currentTrackIndex = 0;
     _.forEach(data, function (item) {
-      if (item.type === 'directory' || item.type === 'playlist') {
-        item.fullName = $scope.directory.name + '/' + item.name;
+      if (item.type === 'directory') {
+        item.fullName = $scope.container.name + '/' + item.name;
         $scope.directories.push(item);
       }
-      // else if (item.type === 'playlist') {
-      //   $scope.playlists.push(item);
-      // }
+      else if (item.type === 'playlist') {
+        item.fullName = $scope.container.name + '/' + item.name;
+        $scope.playlists.push(item);
+      }
       else if (item.type === 'track') {
         (
           function(trackIndex) {
@@ -67,11 +68,20 @@ angular.module('moped.library', [
   });
 })
 
-.directive("subDirectory", function () {
+.directive("directory", function () {
   return {
     restrict: "E",
     scope: { directory: '=' },
-    templateUrl: 'library/subDirectory.tpl.html',
+    templateUrl: 'library/directory.tpl.html',
+    replace:true
+  };
+})
+
+.directive("playlist", function () {
+  return {
+    restrict: "E",
+    scope: { playlist: '=' },
+    templateUrl: 'library/playlist.tpl.html',
     replace:true
   };
 });

--- a/src/app/library/playlist.tpl.html
+++ b/src/app/library/playlist.tpl.html
@@ -1,0 +1,4 @@
+<a ng-href="#/library/{{playlist.uri|directoryUrlEncode}}/{{playlist.fullName|doubleUrlEncode}}" class="list-group-item row">
+    <div class="col-xs-1"><span class="glyphicon glyphicon-music"></span></div>
+    <h4 class="col-xs-10 col-sm-5 list-group-item-heading">{{playlist.name}}</h4>
+</a>

--- a/src/app/library/subDirectory.tpl.html
+++ b/src/app/library/subDirectory.tpl.html
@@ -1,4 +1,0 @@
-<a ng-href="#/library/{{directory.uri|directoryUrlEncode}}/{{directory.fullName|doubleUrlEncode}}" class="list-group-item row">
-    <div class="col-xs-1"><span class="glyphicon glyphicon-folder-close"></span></div>
-    <h4 class="col-xs-10 col-sm-5 list-group-item-heading">{{directory.name}}</h4>
-</a>

--- a/src/app/services/mopidyservice.js
+++ b/src/app/services/mopidyservice.js
@@ -104,7 +104,7 @@ angular.module('moped.mopidy', [])
       getLibrary: function() {
         return wrapMopidyFunc("mopidy.library.browse", this)({ uri: null });
       },
-      getDirectoryItems: function(uri) {
+      getLibraryItems: function(uri) {
         return wrapMopidyFunc("mopidy.library.browse", this)({ uri: uri });
       },
       refresh: function(uri) {


### PR DESCRIPTION
Fix for #25.

Added a new playlist item template for library browsing.
Refactored library browsing, directories and playlists are now both considered containers that can be browsed, both are loaded via 'mopidy.library.browse'.
