### PR TITLE
Update moped.less

### DIFF
--- a/src/less/moped.less
+++ b/src/less/moped.less
@@ -279,7 +279,7 @@ body {
 .controls a:hover,
 .controls a:active,
 .controls a.active {
-  color: #cef;
+  color: #333;
 }
 
 .controls .glyphicon {


### PR DESCRIPTION
Change controls hover and active color for better visualisation of active shuffle function.
Light-blue are very unlucky (too bright)
New Color is orientated on the dark song-info bar at the top of control buttons

@martijnboland
I have closed my duplicate Pull Request #37, so this is my primary Request  