### PR TITLE
fix seekbar slider

### DIFF
--- a/src/app/nowplaying/nowplaying.js
+++ b/src/app/nowplaying/nowplaying.js
@@ -129,7 +129,7 @@ angular.module('moped.nowplaying', [
   function seek(sliderValue) {
     if ($scope.currentTrackLength > 0) {
       var milliSeconds = ($scope.currentTrackLength / 100) * sliderValue;
-      mopidyservice.seek(milliSeconds);      
+      mopidyservice.seek(milliSeconds >> 0);      
     }
   }
 


### PR DESCRIPTION
mopidy is complaining about floating point values that are sent when seeking. This is a simple fix to truncate the value used for seeking before using it.
